### PR TITLE
fix: access document only in browser

### DIFF
--- a/libs/ngx-sonner/src/lib/toaster.component.ts
+++ b/libs/ngx-sonner/src/lib/toaster.component.ts
@@ -180,9 +180,9 @@ export class NgxSonnerToaster implements OnDestroy {
 
   constructor() {
     this.reset();
-    document.addEventListener('keydown', this.handleKeydown);
 
     if (isPlatformBrowser(this.platformId)) {
+      document.addEventListener('keydown', this.handleKeydown);
       window
         .matchMedia('(prefers-color-scheme: dark)')
         .addEventListener('change', this.handleThemePreferenceChange);
@@ -201,8 +201,8 @@ export class NgxSonnerToaster implements OnDestroy {
   }
 
   ngOnDestroy() {
-    document.removeEventListener('keydown', this.handleKeydown);
     if (isPlatformBrowser(this.platformId)) {
+      document.removeEventListener('keydown', this.handleKeydown);
       window
         .matchMedia('(prefers-color-scheme: dark)')
         .removeEventListener('change', this.handleThemePreferenceChange);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
  guidelines: https://github.com/tutkli/ngx-sonner/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Error in sonner toast while starting in SSR application:

```
ReferenceError: document is not defined
    at _NgxSonnerToaster (/Users/m/Dev/me/paddlingspots/node_modules/.pnpm/ngx-sonner@0.4.1_@angular+common@17.3.3_@angular+core@17.3.3/node_modules/ngx-sonner/fesm2022/ngx-sonner.mjs:1393:5)
    at SwipeStateTypes (/Users/m/Dev/me/paddlingspots/node_modules/.pnpm/ngx-sonner@0.4.1_@angular+common@17.3.3_@angular+core@17.3.3/node_modules/ngx-sonner/fesm2022/ngx-sonner.mjs:1458:14)
    at getNodeInjectable (/Users/m/Dev/me/paddlingspots/node_modules/.pnpm/@angular+core@17.3.3_rxjs@7.8.1_zone.js@0.14.4/node_modules/@angular/core/fesm2022/core.mjs:5984:44)
    at instantiateAllDirectives (/Users/m/Dev/me/paddlingspots/node_modules/.pnpm/@angular+core@17.3.3_rxjs@7.8.1_zone.js@0.14.4/node_modules/@angular/core/fesm2022/core.mjs:11907:27)
    at createDirectivesInstances (/Users/m/Dev/me/paddlingspots/node_modules/.pnpm/@angular+core@17.3.3_rxjs@7.8.1_zone.js@0.14.4/node_modules/@angular/core/fesm2022/core.mjs:11306:5)
    at ɵɵelementStart (/Users/m/Dev/me/paddlingspots/node_modules/.pnpm/@angular+core@17.3.3_rxjs@7.8.1_zone.js@0.14.4/node_modules/@angular/core/fesm2022/core.mjs:23014:9)
    at Module.ɵɵelement (/Users/m/Dev/me/paddlingspots/node_modules/.pnpm/@angular+core@17.3.3_rxjs@7.8.1_zone.js@0.14.4/node_modules/@angular/core/fesm2022/core.mjs:23072:5)
    at getActiveTransaction (/Users/m/Dev/me/paddlingspots/libs/ui/ui-sonner-helm/src/lib/hlm-toaster.component.ts:15:5)
    at executeTemplate (/Users/m/Dev/me/paddlingspots/node_modules/.pnpm/@angular+core@17.3.3_rxjs@7.8.1_zone.js@0.14.4/node_modules/@angular/core/fesm2022/core.mjs:11268:9)
    at renderView (/Users/m/Dev/me/paddlingspots/node_modules/.pnpm/@angular+core@17.3.3_rxjs@7.8.1_zone.js@0.14.4/node_modules/@angular/core/fesm2022/core.mjs:12470:13)
```

## What is the new behavior?

Document is only accessed on the browser.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

An alternative would be to use the new lifecycle hook `afterRender`/`afterNextRender` to perform browser specific code (https://angular.dev/guide/ssr#authoring-server-compatible-components).
