### PR TITLE
fix: prevent toasts to be swiped out when not dismissible

### DIFF
--- a/libs/ngx-sonner/src/lib/state.ts
+++ b/libs/ngx-sonner/src/lib/state.ts
@@ -31,7 +31,7 @@ function createToastState() {
         ? data.id
         : toastsCounter++;
 
-    const dismissable = data.dismissable ?? true;
+    const dismissable = data.dismissible ?? true;
     const type = data.type ?? 'default';
 
     const alreadyExists = toasts().find(toast => toast.id === id);
@@ -45,7 +45,7 @@ function createToastState() {
               ...data,
               id,
               title: message,
-              dismissable,
+              dismissible: dismissable,
               type,
               updated: true,
             };
@@ -53,7 +53,7 @@ function createToastState() {
         })
       );
     } else {
-      addToast({ ...rest, id, title: message, dismissable, type });
+      addToast({ ...rest, id, title: message, dismissible: dismissable, type });
     }
 
     return id;

--- a/libs/ngx-sonner/src/lib/state.ts
+++ b/libs/ngx-sonner/src/lib/state.ts
@@ -31,7 +31,7 @@ function createToastState() {
         ? data.id
         : toastsCounter++;
 
-    const dismissable = data.dismissible ?? true;
+    const dismissible = data.dismissible ?? true;
     const type = data.type ?? 'default';
 
     const alreadyExists = toasts().find(toast => toast.id === id);
@@ -45,7 +45,7 @@ function createToastState() {
               ...data,
               id,
               title: message,
-              dismissible: dismissable,
+              dismissible,
               type,
               updated: true,
             };
@@ -53,7 +53,7 @@ function createToastState() {
         })
       );
     } else {
-      addToast({ ...rest, id, title: message, dismissible: dismissable, type });
+      addToast({ ...rest, id, title: message, dismissible: dismissible, type });
     }
 
     return id;

--- a/libs/ngx-sonner/src/lib/toast.component.ts
+++ b/libs/ngx-sonner/src/lib/toast.component.ts
@@ -70,6 +70,7 @@ const defaultClasses: ToastClassnames = {
       [attr.data-index]="index()"
       [attr.data-front]="isFront()"
       [attr.data-swiping]="swiping()"
+      [attr.data-dismissible]="toast().dismissible"
       [attr.data-type]="toastType()"
       [attr.data-invert]="invert()"
       [attr.data-swipe-out]="swipeOut()"
@@ -301,6 +302,10 @@ export class ToastComponent implements AfterViewInit, OnDestroy {
 
   constructor() {
     effect(() => {
+      console.log(this.toast().dismissible);
+    });
+
+    effect(() => {
       const heightIndex = this.heightIndex();
       const toastsHeightBefore = this.toastsHeightBefore();
       untracked(() =>
@@ -389,7 +394,7 @@ export class ToastComponent implements AfterViewInit, OnDestroy {
   }
 
   onPointerDown(event: PointerEvent) {
-    if (this.disabled()) return;
+    if (this.disabled() || !this.toast().dismissible) return;
 
     this.offsetBeforeRemove.set(this.offset());
     const target = event.target as HTMLElement;
@@ -403,7 +408,7 @@ export class ToastComponent implements AfterViewInit, OnDestroy {
   }
 
   onPointerUp() {
-    if (this.swipeOut()) return;
+    if (this.swipeOut() || !this.toast().dismissible) return;
 
     this.pointerStartRef = null;
     const swipeAmount = Number(
@@ -426,7 +431,7 @@ export class ToastComponent implements AfterViewInit, OnDestroy {
   }
 
   onPointerMove(event: PointerEvent) {
-    if (!this.pointerStartRef) return;
+    if (!this.pointerStartRef || !this.toast().dismissible) return;
 
     const yPosition = event.clientY - this.pointerStartRef.y;
     const xPosition = event.clientX - this.pointerStartRef.x;
@@ -449,14 +454,15 @@ export class ToastComponent implements AfterViewInit, OnDestroy {
   }
 
   onCloseButtonClick() {
-    if (this.disabled()) return;
+    if (this.disabled() || !this.toast().dismissible) return;
     this.deleteToast();
     this.toast().onDismiss?.(this.toast());
   }
 
   onCancelClick() {
-    this.deleteToast();
     const toast = this.toast();
+    if (!toast.dismissible) return;
+    this.deleteToast();
     if (toast.cancel?.onClick) {
       toast.cancel.onClick();
     }

--- a/libs/ngx-sonner/src/lib/toast.component.ts
+++ b/libs/ngx-sonner/src/lib/toast.component.ts
@@ -302,10 +302,6 @@ export class ToastComponent implements AfterViewInit, OnDestroy {
 
   constructor() {
     effect(() => {
-      console.log(this.toast().dismissible);
-    });
-
-    effect(() => {
       const heightIndex = this.heightIndex();
       const toastsHeightBefore = this.toastsHeightBefore();
       untracked(() =>

--- a/libs/ngx-sonner/src/lib/toast.component.ts
+++ b/libs/ngx-sonner/src/lib/toast.component.ts
@@ -78,7 +78,7 @@ const defaultClasses: ToastClassnames = {
       (pointerdown)="onPointerDown($event)"
       (pointerup)="onPointerUp()"
       (pointermove)="onPointerMove($event)">
-      @if (toast().dismissable && closeButton() && !toast().component) {
+      @if (toast().dismissible && closeButton() && !toast().component) {
         <button
           aria-label="Close toast"
           [attr.data-disabled]="disabled()"

--- a/libs/ngx-sonner/src/lib/toaster.component.ts
+++ b/libs/ngx-sonner/src/lib/toaster.component.ts
@@ -63,7 +63,7 @@ const GAP = 14;
             (mouseenter)="expanded.set(true)"
             (mousemove)="expanded.set(true)"
             (mouseleave)="handleMouseLeave()"
-            (pointerdown)="interacting.set(true)"
+            (pointerdown)="handlePointerDown($event)"
             (pointerup)="interacting.set(false)"
             [style]="toasterStyles()">
             @for (
@@ -225,10 +225,25 @@ export class NgxSonnerToaster implements OnDestroy {
   }
 
   handleFocus(event: FocusEvent) {
+    const isNotDismissible =
+      event.target instanceof HTMLElement &&
+      event.target.dataset['dismissible'] === 'false';
+
+    if (isNotDismissible) return;
+
     if (!this.isFocusWithinRef()) {
       this.isFocusWithinRef.set(true);
       this.lastFocusedElementRef.set(event.relatedTarget as HTMLElement);
     }
+  }
+
+  handlePointerDown(event: MouseEvent) {
+    const isNotDismissible =
+      event.target instanceof HTMLElement &&
+      event.target.dataset['dismissible'] === 'false';
+
+    if (isNotDismissible) return;
+    this.interacting.set(true);
   }
 
   handleMouseLeave() {

--- a/libs/ngx-sonner/src/lib/types.ts
+++ b/libs/ngx-sonner/src/lib/types.ts
@@ -51,7 +51,7 @@ export type ToastT = {
   };
   onDismiss?: (toast: ToastT) => void;
   onAutoClose?: (toast: ToastT) => void;
-  dismissable?: boolean;
+  dismissible?: boolean;
   promise?: PromiseT;
   style?: Record<string, unknown>;
   class?: string;

--- a/libs/ngx-sonner/src/tests/toaster.spec.ts
+++ b/libs/ngx-sonner/src/tests/toaster.spec.ts
@@ -265,7 +265,7 @@ describe('Toaster', () => {
 
   it('should not show close button if the toast is not dismissable', async () => {
     const { user, trigger, container } = await setup({
-      callback: toast => toast('Hello world', { dismissable: false }),
+      callback: toast => toast('Hello world', { dismissible: false }),
       closeButton: true,
     });
 

--- a/libs/ngx-sonner/src/tests/toaster.spec.ts
+++ b/libs/ngx-sonner/src/tests/toaster.spec.ts
@@ -263,7 +263,7 @@ describe('Toaster', () => {
     expect(closeButton).not.toBeNull();
   });
 
-  it('should not show close button if the toast is not dismissable', async () => {
+  it('should not show close button if the toast is not dismissible', async () => {
     const { user, trigger, container } = await setup({
       callback: toast => toast('Hello world', { dismissible: false }),
       closeButton: true,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our
  guidelines: https://github.com/tutkli/ngx-sonner/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Toasts configured with `dismissible: false` can be swiped out.

Closes #

## What is the new behavior?

- Toast `dismissable` field has been renamed to `dismissible`.
- Toasts can't be swiped out when `dismissible` is set to false.

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- Toast `dismissable` field has been renamed to `dismissible`.

## Other information
