### PR TITLE
feat: add closeButton property to toast options

### DIFF
--- a/libs/ngx-sonner/src/lib/toast.component.ts
+++ b/libs/ngx-sonner/src/lib/toast.component.ts
@@ -79,7 +79,7 @@ const defaultClasses: ToastClassnames = {
       (pointerdown)="onPointerDown($event)"
       (pointerup)="onPointerUp()"
       (pointermove)="onPointerMove($event)">
-      @if (toast().dismissible && closeButton() && !toast().component) {
+      @if (closeButton() && !toast().component) {
         <button
           aria-label="Close toast"
           [attr.data-disabled]="disabled()"
@@ -219,7 +219,9 @@ export class ToastComponent implements AfterViewInit, OnDestroy {
   position = input.required<ToastProps['position']>();
   visibleToasts = input.required<ToastProps['visibleToasts']>();
   expandByDefault = input.required<ToastProps['expandByDefault']>();
-  closeButton = input.required<ToastProps['closeButton']>();
+  _closeButton = input.required<ToastProps['closeButton']>({
+    alias: 'closeButton',
+  });
   interacting = input.required<ToastProps['interacting']>();
   cancelButtonStyle = input<ToastProps['cancelButtonStyle']>();
   actionButtonStyle = input<ToastProps['actionButtonStyle']>();
@@ -268,6 +270,7 @@ export class ToastComponent implements AfterViewInit, OnDestroy {
     }, 0)
   );
   invert = computed(() => this.toast().invert ?? this._invert());
+  closeButton = computed(() => this.toast().closeButton ?? this._closeButton());
   disabled = computed(() => this.toastType() === 'loading');
 
   timeoutId: ReturnType<typeof setTimeout> | undefined;

--- a/libs/ngx-sonner/src/lib/types.ts
+++ b/libs/ngx-sonner/src/lib/types.ts
@@ -35,9 +35,9 @@ export type ToastT = {
   component?: Type<unknown>;
   componentProps?: Record<string, unknown>;
   invert?: boolean;
+  closeButton?: boolean;
+  dismissible?: boolean;
   description?: string | Type<unknown>;
-  cancelButtonStyle?: string;
-  actionButtonStyle?: string;
   duration?: number;
   delete?: boolean;
   important?: boolean;
@@ -51,16 +51,17 @@ export type ToastT = {
   };
   onDismiss?: (toast: ToastT) => void;
   onAutoClose?: (toast: ToastT) => void;
-  dismissible?: boolean;
   promise?: PromiseT;
+  cancelButtonStyle?: string;
+  actionButtonStyle?: string;
   style?: Record<string, unknown>;
+  unstyled?: boolean;
   class?: string;
   classes?: ToastClassnames;
   descriptionClass?: string;
   position?: Position;
-  unstyled?: boolean;
   /**
-   * @internal This is used to determine if the toast has been updated to determine when to reset timer. Hacky but works.
+   * @internal This is used to determine if the toast has been updated to determine when to reset timer.
    */
   updated?: boolean;
 };

--- a/libs/ngx-sonner/src/tests/toaster.spec.ts
+++ b/libs/ngx-sonner/src/tests/toaster.spec.ts
@@ -263,14 +263,25 @@ describe('Toaster', () => {
     expect(closeButton).not.toBeNull();
   });
 
-  it('should not show close button if the toast is not dismissible', async () => {
+  it('should not show close button if the toast has closeButton false', async () => {
     const { user, trigger, container } = await setup({
-      callback: toast => toast('Hello world', { dismissible: false }),
+      callback: toast => toast('Hello world', { closeButton: false }),
       closeButton: true,
     });
 
     await user.click(trigger);
     const closeButton = container.querySelector('[data-close-button]');
     expect(closeButton).toBeNull();
+  });
+
+  it('should show close button if the toast has closeButton true', async () => {
+    const { user, trigger, container } = await setup({
+      callback: toast => toast('Hello world', { closeButton: true }),
+      closeButton: false,
+    });
+
+    await user.click(trigger);
+    const closeButton = container.querySelector('[data-close-button]');
+    expect(closeButton).not.toBeNull();
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our
  guidelines: https://github.com/tutkli/ngx-sonner/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Toaster close button behavior cannot be overridable by the toast function.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #14 

## What is the new behavior?

Added new  `closeButton` property in the toast options to override the toaster behavior.

```ts
// closeButton will override the toaster closeButton
toast('Hello World!',  { closeButton: true })
```

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
