### PR TITLE
fix: only show loading icon when the toast is loading

### DIFF
--- a/libs/ngx-sonner/src/lib/toast.component.ts
+++ b/libs/ngx-sonner/src/lib/toast.component.ts
@@ -91,9 +91,7 @@ import { ToastProps } from './types';
       } @else {
         @if (toastType() !== 'default' || toast().icon || toast().promise) {
           <div data-icon>
-            @if (
-              toast().promise || (toastType() === 'loading' && !toast().icon)
-            ) {
+            @if (toastType() === 'loading' && !toast().icon) {
               <ng-content select="[loading-icon]" />
             }
             @if (toast().icon) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our
  guidelines: https://github.com/tutkli/ngx-sonner/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The loading icon showed when the toast was of type 'promise' not taking into account if the toast was loading or not.

Closes #21 

## What is the new behavior?

The loading icon only shows when the toast is loading.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
