### PR TITLE
fix: prioritize toast position over toaster's

### DIFF
--- a/libs/ngx-sonner/src/lib/toast.component.ts
+++ b/libs/ngx-sonner/src/lib/toast.component.ts
@@ -230,6 +230,7 @@ export class ToastComponent implements AfterViewInit, OnDestroy {
   isVisible = computed(() => this.index() + 1 <= this.visibleToasts());
   toastType = computed(() => this.toast().type ?? 'default');
   toastClass = computed(() => this.toast().class ?? '');
+  toastPosition = computed(() => this.toast().position ?? this.position());
   toastDescriptionClass = computed(() => this.toast().descriptionClass ?? '');
 
   heightIndex = computed(() =>
@@ -242,7 +243,7 @@ export class ToastComponent implements AfterViewInit, OnDestroy {
   lastCloseTimerStartTimeRef = 0;
   pointerStartRef: { x: number; y: number } | null = null;
 
-  coords = computed(() => this.position().split('-'));
+  coords = computed(() => this.toastPosition().split('-'));
   toastsHeightBefore = computed(() =>
     this.heights().reduce((prev, curr, reducerIndex) => {
       if (reducerIndex >= this.heightIndex()) return prev;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] The commit message follows our
  guidelines: https://github.com/tutkli/ngx-sonner/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Toaster position is always used to determine a toast position.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #23 

## What is the new behavior?

Toast individual position is prioritized over the toaster position.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
