### PR TITLE
feat: Overridable CSS variables

### DIFF
--- a/libs/ngx-sonner/src/lib/toaster.component.css
+++ b/libs/ngx-sonner/src/lib/toaster.component.css
@@ -1,34 +1,34 @@
 html[dir='ltr'],
 [data-sonner-toaster][dir='ltr'] {
-    --toast-icon-margin-start: -3px;
-    --toast-icon-margin-end: 4px;
-    --toast-svg-margin-start: -1px;
-    --toast-svg-margin-end: 0px;
-    --toast-button-margin-start: auto;
-    --toast-button-margin-end: 0;
-    --toast-close-button-start: 0;
-    --toast-close-button-end: unset;
-    --toast-close-button-transform: translate(-35%, -35%);
+    --toast-icon-margin-start: var(--ngx-sonner-toast-icon-margin-start, -3px);
+    --toast-icon-margin-end: var(--ngx-sonner-toast-icon-margin-end, 4px);
+    --toast-svg-margin-start: var(--ngx-sonner-toast-svg-margin-start,-1px);
+    --toast-svg-margin-end: var(--ngx-sonner-toast-svg-margin-end, 0px);
+    --toast-button-margin-start: var(--ngx-sonner-toast-button-margin-start, auto);
+    --toast-button-margin-end: var(--ngx-sonner-toast-button-margin-end, 0);
+    --toast-close-button-start: var(--ngx-sonner-toast-close-button-start, 0);
+    --toast-close-button-end: var(--ngx-sonner-toast-close-button-end, unset);
+    --toast-close-button-transform: var(--ngx-sonner-toast-close-button-transform, translate(-35%, -35%));
 }
 
 html[dir='rtl'],
 [data-sonner-toaster][dir='rtl'] {
-    --toast-icon-margin-start: 4px;
-    --toast-icon-margin-end: -3px;
-    --toast-svg-margin-start: 0px;
-    --toast-svg-margin-end: -1px;
-    --toast-button-margin-start: 0;
-    --toast-button-margin-end: auto;
-    --toast-close-button-start: unset;
-    --toast-close-button-end: 0;
-    --toast-close-button-transform: translate(35%, -35%);
+    --toast-icon-margin-start: var(--ngx-sonner-rtl-toast-icon-margin-start, 4px);
+    --toast-icon-margin-end: var(--ngx-sonner-rtl-toast-icon-margin-end, -3px);
+    --toast-svg-margin-start: var(--ngx-sonner-rtl-toast-svg-margin-start, 0px);
+    --toast-svg-margin-end: var(--ngx-sonner-rtl-toast-svg-margin-end, -1px);
+    --toast-button-margin-start: var(--ngx-sonner-rtl-toast-button-margin-start, 0);
+    --toast-button-margin-end: var(--ngx-sonner-rtl-toast-button-margin-end, auto);
+    --toast-close-button-start: var(--ngx-sonner-rtl-toast-close-button-start, unset);
+    --toast-close-button-end: var(--ngx-sonner-rtl-toast-close-button-end, 0);
+    --toast-close-button-transform: var(--ngx-sonner-rtl-toast-close-button-transform, translate(35%, -35%));
 }
 
 [data-sonner-toaster] {
     position: fixed;
     width: var(--width);
-    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,
-    Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji;
+    font-family: var(--ngx-sonner-font-family, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Helvetica Neue, Arial,
+    Noto Sans, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol, Noto Color Emoji);
     --gray1: hsl(0, 0%, 99%);
     --gray2: hsl(0, 0%, 97.3%);
     --gray3: hsl(0, 0%, 95.1%);
@@ -41,7 +41,7 @@ html[dir='rtl'],
     --gray10: hsl(0, 0%, 52.3%);
     --gray11: hsl(0, 0%, 43.5%);
     --gray12: hsl(0, 0%, 9%);
-    --border-radius: 8px;
+    --border-radius: var(--ngx-sonner-border-radius, 8px);
     box-sizing: border-box;
     padding: 0;
     margin: 0;
@@ -185,7 +185,7 @@ html[dir='rtl'],
 }
 
 [data-sonner-toast] [data-button]:focus-visible {
-    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.4);
+    box-shadow: var(--ngx-sonner-toast-focus-box-shadow, 0 0 0 2px rgba(0, 0, 0, 0.4));
 }
 
 [data-sonner-toast] [data-button]:first-of-type {
@@ -213,9 +213,9 @@ html[dir='rtl'],
     justify-content: center;
     align-items: center;
     padding: 0;
-    background: var(--gray1);
-    color: var(--gray12);
-    border: 1px solid var(--gray4);
+    background: var(--ngx-sonner-toast-close-button-background, var(--gray1));
+    color: var(--ngx-sonner-toast-close-button-color, var(--gray12));
+    border: var(--ngx-sonner-toast-close-button-border, 1px solid var(--gray4));
     transform: var(--toast-close-button-transform);
     border-radius: 50%;
     cursor: pointer;
@@ -232,8 +232,9 @@ html[dir='rtl'],
 }
 
 [data-sonner-toast]:hover [data-close-button]:hover {
-    background: var(--gray2);
-    border-color: var(--gray5);
+    background: var(--ngx-sonner-toast-close-button-hover-background, var(--gray2));
+    color: var(--ngx-sonner-toast-close-button-hover-color, var(--gray12));
+    border-color: var(--ngx-sonner-toast-close-button-hover-border-color, var(--gray5));
 }
 
 /* Leave a ghost div to avoid setting hover to false when swiping out */
@@ -383,59 +384,59 @@ html[dir='rtl'],
 }
 
 [data-sonner-toaster][data-theme='light'] {
-    --normal-bg: #fff;
-    --normal-border: var(--gray4);
-    --normal-text: var(--gray12);
+    --normal-bg: var(--ngx-sonner-toast-normal-background, #fff);
+    --normal-border: var(--ngx-sonner-toast-normal-border-color, var(--gray4));
+    --normal-text: var(--ngx-sonner-toast-normal-color, var(--gray12));
 
-    --success-bg: hsl(143, 85%, 96%);
-    --success-border: hsl(145, 92%, 91%);
-    --success-text: hsl(140, 100%, 27%);
+    --success-bg: var(--ngx-sonner-toast-success-background, hsl(143, 85%, 96%));
+    --success-border: var(--ngx-sonner-toast-success-border, hsl(145, 92%, 91%));
+    --success-text: var(--ngx-sonner-toast-success-color, hsl(140, 100%, 27%));
 
-    --info-bg: hsl(208, 100%, 97%);
-    --info-border: hsl(221, 91%, 91%);
-    --info-text: hsl(210, 92%, 45%);
+    --info-bg: var(--ngx-sonner-toast-info-background, hsl(208, 100%, 97%));
+    --info-border: var(--ngx-sonner-toast-info-border, hsl(221, 91%, 91%));
+    --info-text: var(--ngx-sonner-toast-info-color, hsl(210, 92%, 45%));
 
-    --warning-bg: hsl(49, 100%, 97%);
-    --warning-border: hsl(49, 91%, 91%);
-    --warning-text: hsl(31, 92%, 45%);
+    --warning-bg: var(--ngx-sonner-toast-warning-background, hsl(49, 100%, 97%));
+    --warning-border: var(--ngx-sonner-toast-warning-border, hsl(49, 91%, 91%));
+    --warning-text: var(--ngx-sonner-toast-warning-color, hsl(31, 92%, 45%));
 
-    --error-bg: hsl(359, 100%, 97%);
-    --error-border: hsl(359, 100%, 94%);
-    --error-text: hsl(360, 100%, 45%);
+    --error-bg: var(--ngx-sonner-toast-error-background, hsl(359, 100%, 97%));
+    --error-border: var(--ngx-sonner-toast-error-border, hsl(359, 100%, 94%));
+    --error-text: var(--ngx-sonner-toast-error-color, hsl(360, 100%, 45%));
 }
 
 [data-sonner-toaster][data-theme='light'] [data-sonner-toast][data-invert='true'] {
-    --normal-bg: #000;
-    --normal-border: hsl(0, 0%, 20%);
-    --normal-text: var(--gray1);
+    --normal-bg: var(--ngx-sonner-toast-inverse-normal-background, #000);
+    --normal-border: var(--ngx-sonner-toast-inverse-normal-border-color, hsl(0, 0%, 20%));
+    --normal-text: var(--ngx-sonner-toast-inverse-normal-color, var(--gray1));
 }
 
 [data-sonner-toaster][data-theme='dark'] [data-sonner-toast][data-invert='true'] {
-    --normal-bg: #fff;
-    --normal-border: var(--gray3);
-    --normal-text: var(--gray12);
+    --normal-bg: var(--ngx-sonner-toast-inverse-dark-normal-background, #fff);
+    --normal-border: var(--ngx-sonner-toast-inverse-dark-normal-border-color, var(--gray3));
+    --normal-text: var(--ngx-sonner-toast-inverse-dark-normal-color, var(--gray12));
 }
 
 [data-sonner-toaster][data-theme='dark'] {
-    --normal-bg: #000;
-    --normal-border: hsl(0, 0%, 20%);
-    --normal-text: var(--gray1);
+    --normal-bg: var(--ngx-sonner-toast-dark-normal-background, #000);
+    --normal-border: var(--ngx-sonner-toast-dark-normal-border-color, hsl(0, 0%, 20%));
+    --normal-text: var(--ngx-sonner-toast-dark-normal-color, var(--gray1));
 
-    --success-bg: hsl(150, 100%, 6%);
-    --success-border: hsl(147, 100%, 12%);
-    --success-text: hsl(150, 86%, 65%);
+    --success-bg: var(--ngx-sonner-toast-dark-success-background, hsl(150, 100%, 6%));
+    --success-border: var(--ngx-sonner-toast-dark-success-border, hsl(147, 100%, 12%));
+    --success-text: var(--ngx-sonner-toast-dark-success-color, hsl(150, 86%, 65%));
 
-    --info-bg: hsl(215, 100%, 6%);
-    --info-border: hsl(223, 100%, 12%);
-    --info-text: hsl(216, 87%, 65%);
+    --info-bg: var(--ngx-sonner-toast-dark-info-background, hsl(215, 100%, 6%));
+    --info-border: var(--ngx-sonner-toast-dark-info-border, hsl(223, 100%, 12%));
+    --info-text: var(--ngx-sonner-toast-dark-info-color, hsl(216, 87%, 65%));
 
-    --warning-bg: hsl(64, 100%, 6%);
-    --warning-border: hsl(60, 100%, 12%);
-    --warning-text: hsl(46, 87%, 65%);
+    --warning-bg: var(--ngx-sonner-toast-dark-warning-background, hsl(64, 100%, 6%));
+    --warning-border: var(--ngx-sonner-toast-dark-warning-border, hsl(60, 100%, 12%));
+    --warning-text: var(--ngx-sonner-toast-dark-warning-color, hsl(46, 87%, 65%));
 
-    --error-bg: hsl(358, 76%, 10%);
-    --error-border: hsl(357, 89%, 16%);
-    --error-text: hsl(358, 100%, 81%);
+    --error-bg: var(--ngx-sonner-toast-dark-error-background, hsl(358, 76%, 10%));
+    --error-border: var(--ngx-sonner-toast-dark-error-border, hsl(357, 89%, 16%));
+    --error-text: var(--ngx-sonner-toast-dark-error-color, hsl(358, 100%, 81%));
 }
 
 [data-rich-colors='true'] [data-sonner-toast][data-type='success'] {


### PR DESCRIPTION
Replaces hardcoded style values with CSS custom properties (prefixed with `--ngx-sonner`) to allow easier customization and theming of default toast styles. Keeping the previous values as defaults. 

Couldn't find the CONTRIBUTING.md file, hopefully the commit message is alright :)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
  guidelines: https://github.com/tutkli/ngx-sonner/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The toaster component uses CSS variables, but hard-codes the values in the components styles. These styles can currently be overridden through `toastOptions` & custom classes.

## What is the new behavior?

Exposed various properties through unused css variables ex. `--ngx-sonner-toast-normal-background`, while keeping the previous values as fallbacks. This keeps behavior the same, but allows for easy overwrites through css alone. We'd use this feature to better integrate the colors with angular material variables ex: `--ngx-sonner-toast-warning-background: var(--mat-sys-error-container)`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No