### PR TITLE
fix: filter toasts/heights by position in toast to expand toasts grou…

### DIFF
--- a/libs/ngx-sonner/src/lib/toast.component.ts
+++ b/libs/ngx-sonner/src/lib/toast.component.ts
@@ -184,8 +184,12 @@ import { ToastProps } from './types';
 export class ToastComponent implements AfterViewInit, OnDestroy {
   protected readonly cn = cn;
 
-  toasts = toastState.toasts;
-  heights = toastState.heights;
+  toasts = computed(() =>
+    toastState.toasts().filter(t => t.position === this.position())
+  );
+  heights = computed(() =>
+    toastState.heights().filter(h => h.position === this.position())
+  );
   removeHeight = toastState.removeHeight;
   addHeight = toastState.addHeight;
   dismiss = toastState.dismiss;
@@ -327,7 +331,11 @@ export class ToastComponent implements AfterViewInit, OnDestroy {
     this.mounted.set(true);
     const height = this.toastRef().nativeElement.getBoundingClientRect().height;
     this.initialHeight.set(height);
-    this.addHeight({ toastId: this.toast().id, height });
+    this.addHeight({
+      toastId: this.toast().id,
+      height,
+      position: this.position(),
+    });
   }
 
   ngOnDestroy() {

--- a/libs/ngx-sonner/src/lib/toaster.component.ts
+++ b/libs/ngx-sonner/src/lib/toaster.component.ts
@@ -67,7 +67,7 @@ import { Position, Theme, ToasterProps } from './types';
                 [visibleToasts]="visibleToasts()"
                 [closeButton]="closeButton()"
                 [interacting]="interacting()"
-                [position]="position()"
+                [position]="pos"
                 [expandByDefault]="expand()"
                 [expanded]="expanded()"
                 [actionButtonStyle]="toastOptions().actionButtonStyle"

--- a/libs/ngx-sonner/src/lib/types.ts
+++ b/libs/ngx-sonner/src/lib/types.ts
@@ -137,6 +137,7 @@ export type Position =
 export type HeightT = {
   height: number;
   toastId: number | string;
+  position: Position;
 };
 
 export type Theme = 'light' | 'dark' | 'system';


### PR DESCRIPTION
…ped by position

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our
  guidelines: https://github.com/tutkli/ngx-sonner/blob/main/CONTRIBUTING.md#-commit-message-guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Closes #47

## What is the new behavior?

- ToastComponent only has access to other toasts/heights in the same position group
- track position for `HeightT` for filter
- pass the correct position to the ToastComponent

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
